### PR TITLE
WIP - Update AWS Bakery to have bakery_image and add example Azure Bakery

### DIFF
--- a/bakeries.yaml
+++ b/bakeries.yaml
@@ -8,7 +8,7 @@ devseed.bakery.development.aws.us-west-2:
       private:
         protocol: s3
         storage_options:
-          key: DEVSEED_BAKERY_DEVELOPMENT_AWS_US_WEST_2_KEY 
+          key: DEVSEED_BAKERY_DEVELOPMENT_AWS_US_WEST_2_KEY
           secret: DEVSEED_BAKERY_DEVELOPMENT_AWS_US_WEST_2_SECRET
   cluster:
     type: aws.fargate
@@ -27,4 +27,21 @@ devseed.bakery.development.aws.us-west-2:
     flow_storage_options:
       key: DEVSEED_BAKERY_DEVELOPMENT_AWS_US_WEST_2_KEY
       secret: DEVSEED_BAKERY_DEVELOPMENT_AWS_US_WEST_2_SECRET
+    max_workers: 10
+devseed.bakery.development.azure.ukwest:
+  region: azure.ukwest
+  targets:
+    ciarandev-bakery-flow-cache-container:
+      description: "Internal Storage Container for Flow outputs"
+      private:
+        protocol: abfs
+        storage_options:
+          connection_string: DEVSEED_BAKERY_DEVELOPMENT_AZURE_UKWEST_CONNECTION_STRING
+  cluster:
+    type: azure.aks
+    bakery_image: pangeo/pangeo-forge-bakery-images:pangeonotebook-2021.05.15_prefect-0.14.19_pangeoforgerecipes-0.3.4
+    flow_storage: ciarandev-bakery-flow-storage-container
+    flow_storage_protocal: abfs
+    flow_storage_options:
+      connection_string: DEVSEED_BAKERY_DEVELOPMENT_AZURE_UKWEST_CONNECTION_STRING
     max_workers: 10


### PR DESCRIPTION
## What I am changing

TL;DR: This PR  adds an example entry of the Azure Bakery. The values of the Azure Bakery will change when we actually get it deployed in MS accounts.

## How I did it
* Add an example entry of what I think the Azure Bakery structure will follow. A lot less is needed to provide to the Executor. 

@sharkinsspatial I'll wait on this going in till we've deployed both Bakeries in their new forms, but can you give this a sanity check for me? 